### PR TITLE
Use voting aggregator to aggregate token manager hooks as well

### DIFF
--- a/apps/voting-aggregator/arapp.json
+++ b/apps/voting-aggregator/arapp.json
@@ -56,6 +56,10 @@
         "New weight",
         "Old weight"
       ]
+    },
+    {
+      "name": "Manage Plugged Hook",
+      "id": "MANAGE_PLUGGED_HOOK_ROLE"
     }
   ],
   "path": "contracts/VotingAggregator.sol"

--- a/apps/voting-aggregator/contracts/interfaces/ITokenManager.sol
+++ b/apps/voting-aggregator/contracts/interfaces/ITokenManager.sol
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity ^0.4.24;
+
+
+interface ITokenManager {
+    function token() external view returns (address);
+}

--- a/apps/voting-aggregator/package.json
+++ b/apps/voting-aggregator/package.json
@@ -28,6 +28,7 @@
     "prepublishOnly": "truffle compile --all && npm run abi:extract -- --no-compile"
   },
   "dependencies": {
+    "@1hive/apps-token-manager": "^3.0.5",
     "@aragon/os": "4.3.0",
     "@aragonone/voting-connectors-contract-utils": "^1.0.0"
   },


### PR DESCRIPTION
Until now we only could register hooks (such as Conviction Voting) directly to the Hooked Token Manager, so we were forced to use just one token to govern the funding in Gardens:

![single-token-conviction](https://user-images.githubusercontent.com/931684/132240106-bf42a44a-9759-47db-b35e-264e7c2b605e.png)

[We are planing to de-hookify garden tokens in Gardens v2](https://forum.1hive.org/t/are-token-manager-hooks-useful-anymore/4288), so we will have more freedom in the future to do multi-token gardens, and use garden tokens in multiple gardens.

This pull requests modifies the Voting Aggregator to make it a token manager hook (registrable for many Hooked Token Managers as seen below) and send the events to the hook it is plugging (such as Conviction Voting).

![multi-token-conviction](https://user-images.githubusercontent.com/931684/132240390-357c1e26-b06d-4a6b-bd5d-5c26bd4a3b45.png)

Each time any of the garden tokens is transferred, the voting aggregator `onTransfer` hook is going to be called, calling at once the plugged hook's `onTransfer` hook with an amount weighted by the voting aggregator configuration.

Note that in order to use this feature all power sources in the voting aggregator must register it as a hook. Once a hook has been plugged in, no power sources can be added, enabled, or disabled, or their weights can change until the hook is not removed. This is done to prevent unintended effects. 


To do:
- [ ] Write tests